### PR TITLE
Allow and check for undefined credential in login

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -141,6 +141,11 @@ export class Learn2018Helper {
       const credential = await this.#provider();
       username = credential.username;
       password = credential.password;
+      if (!username || !password) {
+        return Promise.reject({
+          reason: FailReason.NO_CREDENTIAL,
+        } as ApiError);
+      }
     }
     const ticketResponse = await this.#rawFetch(URL.ID_LOGIN(), {
       body: URL.ID_LOGIN_FORM_DATA(username, password),

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 import type { CookieJar } from 'tough-cookie';
 
 export type Fetch = typeof globalThis.fetch;
-export type Credential = { username: string; password: string };
+export type Credential = { username?: string; password?: string };
 export type CredentialProvider = () => Credential | Promise<Credential>;
 export type HelperConfig = {
   provider?: CredentialProvider;


### PR DESCRIPTION
`provider` 接受 Promise 的话还是有几率拿不到数据的。允许 undefined 让 typing 稍微舒服一点。