### PR TITLE
Discriminate `getAllContents` return type based on input content type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -268,13 +268,19 @@ interface IQuestion extends IDiscussionBase {
 
 export type Question = IQuestion;
 
-export type Content = Notification | File | Homework | Discussion | Question;
+export type ContentTypeMap = {
+  [ContentType.NOTIFICATION]: Notification;
+  [ContentType.FILE]: File;
+  [ContentType.HOMEWORK]: Homework;
+  [ContentType.DISCUSSION]: Discussion;
+  [ContentType.QUESTION]: Question;
+};
 
-interface ICourseContent {
-  [id: string]: Content[];
+interface ICourseContent<T extends ContentType> {
+  [id: string]: ContentTypeMap[T][];
 }
 
-export type CourseContent = ICourseContent;
+export type CourseContent<T extends ContentType> = ICourseContent<T>;
 
 export interface CalendarEvent {
   location: string;


### PR DESCRIPTION
自动根据传入 `type` 推断返回内容的类型。

switch 的地方实在想不到什么简洁的办法了。